### PR TITLE
追加学習及び推論時に学習時に存在しないカテゴリ値が与えられた時の対応

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,4 +20,4 @@ pyspark = "*"
 scikit-learn = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/cognimaker/preprocessor/_base.py
+++ b/cognimaker/preprocessor/_base.py
@@ -115,11 +115,10 @@ class BasePreprocessor(ABC):
         return spark_data_frame, spark_context, sql_context
 
     def _set_category_value_dict(self, spark_df):
-        if self.categorical_columns:
-            for column in self.categorical_columns:
-                if column in spark_df.columns:
-                    self.category_value_dict[column] = \
-                        spark_df.select(column).distinct().rdd.map(lambda r: r[0]).collect()
+        for column in self.categorical_columns:
+            if column in spark_df.columns:
+                self.category_value_dict[column] = \
+                    spark_df.select(column).distinct().rdd.map(lambda r: r[0]).collect()
 
     def _filter(self, spark_df):
         """

--- a/cognimaker/preprocessor/_base.py
+++ b/cognimaker/preprocessor/_base.py
@@ -115,7 +115,14 @@ class BasePreprocessor(ABC):
         return spark_data_frame, spark_context, sql_context
 
     def _set_category_value_dict(self, spark_df):
+        """
+        カテゴリカラムのユニーク値をdictに保存するメソッド
+        param
+            spark_df: 読み込んだspark Data Frame
+        """
         for column in self.categorical_columns:
+            # categorical_columnsにはモデルが受け入れるカラムのリストを入れるので、
+            # spark_dfに含まれているカラムのみdictに入れる。
             if column in spark_df.columns:
                 self.category_value_dict[column] = \
                     spark_df.select(column).distinct().rdd.map(lambda r: r[0]).collect()

--- a/cognimaker/preprocessor/_base.py
+++ b/cognimaker/preprocessor/_base.py
@@ -146,7 +146,7 @@ class BasePreprocessor(ABC):
                     count_after = spark_df.count()
                     excluded_count = count_before - count_after
                     self.__logger.warning(
-                        "カラム：{0} に学習時にないカテゴリ：{1} が含まれています。\n" \
+                        "カラム：{0} に学習時にないカテゴリ：{1} が含まれています。" \
                         "{2}レコードが除外されました。".format(k, not_train_values, excluded_count)
                     )
 

--- a/cognimaker/preprocessor/_base.py
+++ b/cognimaker/preprocessor/_base.py
@@ -35,7 +35,7 @@ class BasePreprocessor(ABC):
 
     def __init__(
         self, input_path: str, output_path: str, pickle_path: str,
-        categorical_columns: list,
+        categorical_columns: list = None,
         purpose: str = 'train', load_pickle_path: str = None
     ):
         """
@@ -113,17 +113,18 @@ class BasePreprocessor(ABC):
             .load(self.input_path)
 
         if self.purpose == 'train':
-            self.set_category_value_dict(spark_data_frame)
+            self._set_category_value_dict(spark_data_frame)
         else:
             spark_data_frame = self._filter(spark_data_frame)
 
         return spark_data_frame, spark_context, sql_context
 
-    def set_category_value_dict(self, spark_df):
-        for column in self.categorical_columns:
-            if column in spark_df.columns:
-                self.category_value_dict[column] = \
-                    spark_df.select(column).distinct().rdd.map(lambda r: r[0]).collect()
+    def _set_category_value_dict(self, spark_df):
+        if self.categorical_columns:
+            for column in self.categorical_columns:
+                if column in spark_df.columns:
+                    self.category_value_dict[column] = \
+                        spark_df.select(column).distinct().rdd.map(lambda r: r[0]).collect()
 
     def _filter(self, spark_df):
         """

--- a/tests/tests_preprocessor/test_preprocessor.py
+++ b/tests/tests_preprocessor/test_preprocessor.py
@@ -4,6 +4,12 @@ import os
 
 from cognimaker.preprocessor import BasePreprocessor
 
+CATEGORY_COLUMNS = [
+    '性別',
+    '年代',
+    '販売店',
+    'カテゴリ'
+]
 
 class Preprocessor(BasePreprocessor):
 
@@ -105,9 +111,9 @@ class PreprocessorTestCase(unittest.TestCase):
             input_path="s3a://cognimaker-test/input/test.csv",
             output_path="s3://cognimaker-test/output/test.csv",
             pickle_path="s3://cognimaker-test/pickle/train_preprocessor.pickle",
-            purpose="train"
+            purpose="train",
+            categorical_columns = CATEGORY_COLUMNS
         )
-
         preprocessor.preprocess()
 
     def test_1_transform_predict(self):
@@ -116,9 +122,9 @@ class PreprocessorTestCase(unittest.TestCase):
             output_path="s3://cognimaker-test/output/test_drop.csv",
             pickle_path="s3://cognimaker-test/pickle/predict_preprocessor.pickle",
             purpose="predict",
+            categorical_columns = CATEGORY_COLUMNS,
             load_pickle_path="s3://cognimaker-test/pickle/train_preprocessor.pickle"
         )
-
         preprocessor.preprocess()
 
     def test_2_transform_train_local(self):
@@ -126,9 +132,9 @@ class PreprocessorTestCase(unittest.TestCase):
             input_path=os.path.dirname(os.path.abspath(__file__)) + "/test_input.csv",
             output_path=os.path.dirname(os.path.abspath(__file__)) + "/test_output.csv",
             pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/train_preprocessor.pickle",
-            purpose="train"
+            purpose="train",
+            categorical_columns = CATEGORY_COLUMNS
         )
-
         preprocessor.preprocess()
 
     def test_3_transform_predict_local(self):
@@ -137,19 +143,20 @@ class PreprocessorTestCase(unittest.TestCase):
             output_path=os.path.dirname(os.path.abspath(__file__)) + "/test_output_drop.csv",
             pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/predict_preprocessor.pickle",
             purpose="predict",
+            categorical_columns = CATEGORY_COLUMNS,
             load_pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/train_preprocessor.pickle"
         )
-
         preprocessor.preprocess()
 
-    def test_4_transform_train_local_error(self):
+    def test_4_transform_predict_add_category(self):
         preprocessor = Preprocessor(
-            input_path=os.path.dirname(os.path.abspath(__file__)) + "/not_exist.csv",
-            output_path=os.path.dirname(os.path.abspath(__file__)) + "/test_output_error.csv",
-            pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/train_error.pickle",
-            purpose="train",
+            input_path=os.path.dirname(os.path.abspath(__file__)) + "/test_input_add.csv",
+            output_path=os.path.dirname(os.path.abspath(__file__)) + "/test_output_add.csv",
+            pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/predict_add.pickle",
+            purpose="predict",
+            categorical_columns = CATEGORY_COLUMNS,
+            load_pickle_path=os.path.dirname(os.path.abspath(__file__)) + "/train_preprocessor.pickle"
         )
-
         preprocessor.preprocess()
 
 


### PR DESCRIPTION
学習時にカテゴリカラムとして指定されたカラムのユニーク値を保存し、
予測・追加学習時には保存した値にもとづいてフィルターをかけるようにしている。

インスタンス生成時に、カテゴリカラムの指定の引数が増えているが、以前のバージョンのスクリプトでも動くようにデフォルト値`None`を設定している。