### PR TITLE
前処理後にレコードがなくなった場合エラーにする。

### DIFF
--- a/cognimaker/preprocessor/_base.py
+++ b/cognimaker/preprocessor/_base.py
@@ -177,6 +177,10 @@ class BasePreprocessor(ABC):
         param
             pandas_df: 出力するpandas DataFrame
         """
+        # レコード数が0の時はエラーとする
+        if len(pandas_df) == 0:
+            raise ValueError("前処理結果のレコード数が0です。")
+
         if BasePreprocessor._is_s3_path(self.output_path):
             buffer = StringIO()
             pandas_df[self.output_columns].to_csv(buffer, index=False, header=False)


### PR DESCRIPTION
#20 

想定される状況は以下の２点
- CSVダウンロード時点でレコードが０件（指定期間にレコードが存在しない）
- 推論・追加学習時にカテゴリデータをフィルタしたことにより、０件になる。

いずれの場合も、前処理の出力の時点でレコードが０件の場合エラーにしている。