### PR TITLE
モデル評価の実装を修正

### DIFF
--- a/cognimaker/estimator/_base.py
+++ b/cognimaker/estimator/_base.py
@@ -81,12 +81,43 @@ class BaseEstimator(ABC):
 
     @abstractmethod
     def choose_evaluation(self, num_rows) -> dict:
+        """
+        モデルの評価方法を選択するためのメソッド
+
+        評価方法としてクロスバリデーションかテストスプリットかを選択できる。選択するには
+        このメソッドを継承して評価方法を指定したdictを返す。要求されるdictを返すためには
+        `self.choose_cross_validation()`メソッドか`self.choose_test_split()`
+        メソッドを呼び出してその返り値を返すことが推奨される。
+
+        データの行数を渡されるのでデータ量を条件に評価方法を選択することも可能。
+
+        param
+            num_rows: データの行数
+        """
         raise NotImplementedError()
 
     def choose_cross_validation(self, num_splits=5, repeats=1) -> dict:
+        """
+        クロスバリデーション評価方法を選択するdictを返す
+
+        クロスバリデーションのスプリット数と試行回数を指定できる。試行回数が２以上の場合、
+        データ全体で複数回クロスバリデーションを行う（毎回スプリットはランダム）。
+
+        param
+            num_splits: スプリットの数
+            repeats: 試行回数
+        """
         return dict(method='cv', num_splits=num_splits, repeats=repeats)
 
     def choose_test_split(self, test_size=0.2) -> dict:
+        """
+        テストスプリット評価方法を選択するdictを返す
+
+        テストスプリットの大きさ（データ全体の割合）を指定できる。
+
+        param
+            test_size: テストスプリットの大きさ 有効範囲：(0, 1.0)
+        """
         return dict(method='split',  test_size=test_size)
 
     @abstractmethod

--- a/cognimaker/estimator/_base_classifier.py
+++ b/cognimaker/estimator/_base_classifier.py
@@ -17,33 +17,44 @@ class BaseClassifier(BaseEstimator):
     """
     クラス分類モデル（２値分類）の基底クラス
     """
-    def calc_indicators(self, model, X, y):
+    def calc_indicators(self, model, X, y) -> dict:
         """
-        以下の指標を算出し、self.indicatorsに格納する
+        モデルの評価指標を算出するメソッド
+
+        以下の指標を算出し返す
         正解率、適合率、再現率、混同行列、AUC、ROC、
+
+        Args:
+            model: 学習済みのモデルインスタンス
+            X: 指標算出用の入力データ
+            y: 指標算出用の教師データ
+        return
+            indicators: インジケーターを格納した辞書オブジェクト
         """
         # 予測確率と予測結果の算出
         predict_proba = self.get_predict_proba(model, X)
         y_pred = self.get_predict(model, X)
 
+        indicators = {}
+
         # 正解率
         accuracy = accuracy_score(y, y_pred)
-        self.indicators["accuracy"] = accuracy
+        indicators["accuracy"] = accuracy
         self.logger.info("accuracy={:.4f};".format(accuracy))
 
         # 適合率
         precision = precision_score(y, y_pred)
-        self.indicators["precision"] = precision
+        indicators["precision"] = precision
         self.logger.info("precision={:.4f};".format(precision))
 
         # 再現率
         recall = recall_score(y, y_pred)
-        self.indicators["recall"] = recall
+        indicators["recall"] = recall
         self.logger.info("recall={:.4f};".format(recall))
 
         # 混同行列
         cm = confusion_matrix(y, y_pred)
-        self.indicators["confusion_matrix"] = {
+        indicators["confusion_matrix"] = {
             "TN": cm[0][0],
             "FP": cm[0][1],
             "FN": cm[1][0],
@@ -54,23 +65,126 @@ class BaseClassifier(BaseEstimator):
         # AUC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
         try:
             auc = roc_auc_score(y, predict_proba)
-            self.indicators["auc"] = auc
+            indicators["auc"] = auc
             self.logger.info("auc={:.4f};".format(auc))
         except Exception as e:
-            self.indicators["auc"] = None
+            indicators["auc"] = None
             self.logger.error(str(e))
 
         # ROC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
         try:
             fpr, tpr, thresholds = roc_curve(y, predict_proba)
             # ROC曲線は、fprを横軸、tprを縦軸にプロットしたもの
-            self.indicators["roc"] = {
+            indicators["roc"] = {
                 "fpr": fpr, #偽陽性率
                 "tpr": tpr #真陽性率
             }
         except Exception as e:
-            self.indicators["roc"] = {}
+            indicators["roc"] = {}
             self.logger.error(str(e))
+
+        return indicators
+
+    def log_indicators(self) -> None:
+        """
+        ログのために標準出力にモデルの評価指標を出力するメソッド
+        """
+        # 正解率
+        accuracy = self.indicators["accuracy"] 
+        self.logger.info("accuracy={:.4f};".format(accuracy))
+
+        # 適合率
+        precision = self.indicators["precision"] 
+        self.logger.info("precision={:.4f};".format(precision))
+
+        # 再現率
+        recall = self.indicators["recall"] 
+        self.logger.info("recall={:.4f};".format(recall))
+
+        # 混同行列
+        cm = self.indicators["confusion_matrix"]
+        self.logger.info("confusion_matrix \n {};".format(cm))
+
+        # AUC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
+        auc = self.indicators["auc"] 
+        self.logger.info("auc={:.4f};".format(auc))
+
+    def combine_indicators(self, indicators: list) -> dict:
+        """
+        クロスバリデーションの場合に複数のモデルの評価指標を一つに集約するメソッド
+
+        基本的にはそれぞれの指標の値の平均を算出する
+        """
+
+        indicator_count = len(indicators)
+
+        # 正解率
+        accuracy = 0
+        for ind in indicators:
+            accuracy = accuracy + ind["accuracy"] 
+        accuracy = accuracy / indicator_count
+
+        # 適合率
+        precision = 0
+        for ind in indicators:
+            precision = precision + ind["precision"] 
+        precision = precision / indicator_count
+
+        # 再現率
+        recall = 0
+        for ind in indicators:
+            recall = recall + ind["recall"] 
+        recall = recall / indicator_count
+
+        # 混同行列
+        cm = { "TN": 0, "FP": 0, "FN": 0, "TP": 0 }
+        for ind in indicators:
+            cm["TN"] = cm["TN"] + ind["confusion_matrix"]["TN"]
+            cm["FP"] = cm["FP"] + ind["confusion_matrix"]["FP"]
+            cm["FN"] = cm["FN"] + ind["confusion_matrix"]["FN"]
+            cm["TP"] = cm["TP"] + ind["confusion_matrix"]["TP"]
+        cm["TN"] = cm["TN"] / indicator_count
+        cm["FP"] = cm["FP"] / indicator_count
+        cm["FN"] = cm["FN"] / indicator_count
+        cm["TP"] = cm["TP"] / indicator_count
+        
+
+        # AUC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
+        auc = 0
+        auc_cnt = indicator_count
+        for ind in indicators:
+            if ind["auc"] is not None:
+                auc = auc + ind["auc"] 
+            else:
+                auc_cnt = auc_cnt - 1
+        auc = auc / auc_cnt
+
+        # 偽陽性率、真陽性率をそれぞれ平均してROCとして算出
+        # モデルごとのROC曲線ではX軸の真陽性率の値が異なるため線形補完して合わせる
+        mean_fpr = np.linspace(0, 1, 100)
+        tprs = []
+        for ind in indicators:
+            if "fpr" in ind["roc"]:
+                interp_tpr = np.interp(mean_fpr, ind["roc"]["fpr"], ind["roc"]["tpr"])
+                interp_tpr[0] = 0.0
+                tprs.append(interp_tpr)
+        mean_tpr = np.mean(tprs, axis=0)
+        mean_tpr[-1] = 1.0
+        roc = {
+            "fpr": mean_fpr,
+            "tpr": mean_tpr
+        }
+
+        result = {
+            "accuracy": accuracy,
+            "precision": precision,
+            "recall": recall,
+            "confusion_matrix": cm,
+            "auc": auc,
+            "roc": roc
+        }
+
+        return result
 
     @abstractmethod
     def get_predict_proba(self, model, X):

--- a/cognimaker/estimator/_base_classifier.py
+++ b/cognimaker/estimator/_base_classifier.py
@@ -40,17 +40,14 @@ class BaseClassifier(BaseEstimator):
         # 正解率
         accuracy = accuracy_score(y, y_pred)
         indicators["accuracy"] = accuracy
-        # self.logger.info("accuracy={:.4f};".format(accuracy))
 
         # 適合率
         precision = precision_score(y, y_pred)
         indicators["precision"] = precision
-        # self.logger.info("precision={:.4f};".format(precision))
 
         # 再現率
         recall = recall_score(y, y_pred)
         indicators["recall"] = recall
-        # self.logger.info("recall={:.4f};".format(recall))
 
         # 混同行列
         cm = confusion_matrix(y, y_pred)
@@ -60,13 +57,11 @@ class BaseClassifier(BaseEstimator):
             "FN": cm[1][0],
             "TP": cm[1][1]
         }
-        # self.logger.info("confusion_matrix \n {};".format(cm))
 
         # AUC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
         try:
             auc = roc_auc_score(y, predict_proba)
             indicators["auc"] = auc
-            # self.logger.info("auc={:.4f};".format(auc))
         except Exception as e:
             indicators["auc"] = None
             self.logger.error(str(e))

--- a/cognimaker/estimator/_base_classifier.py
+++ b/cognimaker/estimator/_base_classifier.py
@@ -40,17 +40,17 @@ class BaseClassifier(BaseEstimator):
         # 正解率
         accuracy = accuracy_score(y, y_pred)
         indicators["accuracy"] = accuracy
-        self.logger.info("accuracy={:.4f};".format(accuracy))
+        # self.logger.info("accuracy={:.4f};".format(accuracy))
 
         # 適合率
         precision = precision_score(y, y_pred)
         indicators["precision"] = precision
-        self.logger.info("precision={:.4f};".format(precision))
+        # self.logger.info("precision={:.4f};".format(precision))
 
         # 再現率
         recall = recall_score(y, y_pred)
         indicators["recall"] = recall
-        self.logger.info("recall={:.4f};".format(recall))
+        # self.logger.info("recall={:.4f};".format(recall))
 
         # 混同行列
         cm = confusion_matrix(y, y_pred)
@@ -60,13 +60,13 @@ class BaseClassifier(BaseEstimator):
             "FN": cm[1][0],
             "TP": cm[1][1]
         }
-        self.logger.info("confusion_matrix \n {};".format(cm))
+        # self.logger.info("confusion_matrix \n {};".format(cm))
 
         # AUC（教師データに片方のラベルしか無い場合エラーになるので例外処理をいれる）
         try:
             auc = roc_auc_score(y, predict_proba)
             indicators["auc"] = auc
-            self.logger.info("auc={:.4f};".format(auc))
+            # self.logger.info("auc={:.4f};".format(auc))
         except Exception as e:
             indicators["auc"] = None
             self.logger.error(str(e))


### PR DESCRIPTION
モデルを評価するとき、クロスバリデーションかテストスプリットの方法が
選択できるように修正する。クロスバリデーションの分割数やテストスプリットの
大きさを選択する関数を用意する。モデルの修正も必要になる。

クロスバリデーションの場合のスコアの計算の都合で`log_score`メソッドも修正する必要があった。